### PR TITLE
alterando uso do path separator para o da class Platform

### DIFF
--- a/lib/core/utils/directory_utils.dart
+++ b/lib/core/utils/directory_utils.dart
@@ -8,12 +8,12 @@ class DirectoryUtils {
     if (Directory(path).existsSync()) {
       return;
     }
-    var complete = path.split('\\')[0];
+    var complete = path.split(Platform.pathSeparator)[0];
     final exist = Directory(complete).existsSync();
     if (!exist) Directory(complete).createSync();
-    
-    for (var i = 1; i < path.split('\\').length; i++) {
-      final e = path.split('\\')[i];
+
+    for (var i = 1; i < path.split(Platform.pathSeparator).length; i++) {
+      final e = path.split(Platform.pathSeparator)[i];
       if (e.isEmpty) continue;
 
       complete += '/$e';

--- a/lib/core/utils/reserved_words.dart
+++ b/lib/core/utils/reserved_words.dart
@@ -186,9 +186,7 @@ class ReservedWords {
 
   static String? _replaceWordWithOptions(String word) {
     final action = {
-      'module': Platform.isMacOS
-          ? '${GlobalVariable.path.split('/').last}'
-          : '${GlobalVariable.path.split('\\').last}',
+      'module': '${GlobalVariable.path.split(Platform.pathSeparator).last}',
       'name': GlobalVariable.name,
       'path': GlobalVariable.path,
       'repositoryPathInterface': RepositoryInterfaceDesignPattern().path(),

--- a/lib/core/utils/triggers_utils.dart
+++ b/lib/core/utils/triggers_utils.dart
@@ -160,8 +160,8 @@ class TriggersUtils {
 
   static String _pathFolder(String pathFile) {
     return pathFile
-        .split('\\')
-        .sublist(0, pathFile.split('\\').length - 1)
-        .join('\\');
+        .split(Platform.pathSeparator)
+        .sublist(0, pathFile.split(Platform.pathSeparator).length - 1)
+        .join(Platform.pathSeparator);
   }
 }


### PR DESCRIPTION
Não estava sendo possível utilizar a lib no macOS por causa dos path separators, ajustei para usar ela pela classe Platform que vai usar a correta para cada sistema. Depois dessa alteração eu consegui criar normalmente aqui no macOS.

Como não temos testes ainda não tenho certeza se não quebrei nada com essa modificação 😲